### PR TITLE
Delete babel@6 dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "babel": "^6.5.2",
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
You should be able to eliminate this as `babel@6` doesn't do anything useful, it just points
to `babel-core` and `babel-cli` =)

Is there a license for this repo? The only sign I see is `ISC` in `package.json`, but I take that with a grain of salt since it most frequently ends up there as result of following the prompts for `npm init`, and most projects have a `LICENSE` file at the root.
