### PR TITLE
Add tests framework and TODO comments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,8 @@
 {
   "parser": "babel-eslint",
-  "extends": ["airbnb"]
+  "extends": ["airbnb"],
+  "env": {
+    "browser": true,
+    "mocha": true
+  }
 }

--- a/app/assets/javascripts/actions.js
+++ b/app/assets/javascripts/actions.js
@@ -1,4 +1,3 @@
-/* globals fetch */
 import 'whatwg-fetch';
 
 // TYPES

--- a/app/assets/javascripts/app.jsx
+++ b/app/assets/javascripts/app.jsx
@@ -1,4 +1,3 @@
-/* globals fetch, document */
 import React, { Component } from 'react';
 import { render } from 'react-dom';
 import PropTypes from 'prop-types';
@@ -6,6 +5,14 @@ import { connect, Provider } from 'react-redux';
 import 'whatwg-fetch';
 import { create } from './actions';
 import configureStore from './configureStore';
+
+// TODO:
+//  - move API call inside `componentWillMount` to Redux
+//  - implement the following features in the component and with Redux:
+//    * editing the text of a todo
+//    * check/un-checking a todo as dsone
+//    * deleting a todo
+//  - testing of Redux code is a plus. Write your tests in `rails-react-base/spec/javascripts/`
 
 class App extends Component {
   static propTypes = {
@@ -31,7 +38,6 @@ class App extends Component {
     };
   }
 
-  // TODO: move this API call to Redux
   async componentWillMount() {
     const response = await fetch('/todo_items');
     const data = await response.json();

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,6 +188,11 @@
         "util": "0.10.3"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -1502,6 +1507,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+    },
     "browserify-aes": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
@@ -1632,6 +1642,19 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1643,6 +1666,11 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
       "version": "1.7.0",
@@ -1726,6 +1754,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -1876,6 +1909,14 @@
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1920,6 +1961,11 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -2514,6 +2560,15 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
+      }
+    },
+    "fetch-mock": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.0.0.tgz",
+      "integrity": "sha512-xbQ+zQClDhnzPMoerhkRv6hTN9doVRxOeHRqeSHPFwxTuMo5ufGU383ByoeS3FmuXMS86I4Bz0Rj5Y1vZ8DTUw==",
+      "requires": {
+        "glob-to-regexp": "0.3.0",
+        "path-to-regexp": "2.1.0"
       }
     },
     "figures": {
@@ -3411,6 +3466,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3446,6 +3506,11 @@
         "is-glob": "2.0.1"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -3468,6 +3533,11 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
     },
     "has": {
       "version": "1.0.1",
@@ -3506,6 +3576,11 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4020,6 +4095,11 @@
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -4186,6 +4266,41 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -4493,6 +4608,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
+    "path-to-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
+      "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw=="
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -4500,6 +4620,11 @@
       "requires": {
         "pify": "2.3.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -4786,6 +4911,14 @@
       "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
       "requires": {
         "deep-diff": "0.3.8"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
+      "integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+      "requires": {
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "redux-thunk": {
@@ -5294,6 +5427,11 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "rails": "bundle exec rails server -b 0.0.0.0",
     "webpack": "webpack --watch",
-    "start": "npm-run-all --parallel webpack rails",
-    "lint": "eslint --fix 'app/assets/javascripts/**/*.js' && bundle exec rubocop -a -D -c rubocop.yml"
+    "start": "npm-run-all --parallel webpack rails test",
+    "lint": "eslint --fix 'app/assets/javascripts/**/*.js' && bundle exec rubocop -a -D -c rubocop.yml",
+    "test": "mocha --require babel-polyfill --require babel-register --watch ./spec/javascripts/**/*.js"
   },
   "author": "Sonian",
   "dependencies": {
@@ -18,6 +19,8 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.26.0",
+    "chai": "^4.1.2",
     "co": "^4.6.0",
     "eslint": "^4.8.0",
     "eslint-config-airbnb": "^15.1.0",
@@ -25,6 +28,8 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.4.0",
+    "fetch-mock": "^6.0.0",
+    "mocha": "^5.0.1",
     "npm-run-all": "^4.1.1",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
@@ -32,9 +37,9 @@
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
+    "redux-mock-store": "^1.5.1",
     "redux-thunk": "^2.2.0",
     "webpack": "^3.6.0",
     "whatwg-fetch": "^2.0.3"
-  },
-  "devDependencies": {}
+  }
 }

--- a/spec/javascripts/actionsSpec.js
+++ b/spec/javascripts/actionsSpec.js
@@ -1,0 +1,9 @@
+const expect = require('chai').expect;
+
+// For a good idea of how Redux action creators are tested take a look at the
+// documentation: https://redux.js.org/docs/recipes/WritingTests.html#action-creators
+describe('Action Creators', () => {
+  it('adds', () => {
+    expect(1 + 1).to.equal(2);
+  });
+});


### PR DESCRIPTION
* A simple test framework was added to run automatically with `bin/dev`
and any changes made to `spec/javascripts/`. Dependencies that could be
used in testing were pre-added to `package.json` for ease of use.

* Comments were made in main component file to document what needs to be
completed.

* Updates to .eslintrc to remove having to comment globals for global
browser and mocha variables.